### PR TITLE
Allow diagnostics provider to parse clang for Windows output

### DIFF
--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import * as clang from './clang';
 
-export const diagnosticRe = /^\<stdin\>:(\d+):(\d+):(?:((?:\{.+?\})+):)? ((?:fatal )?error|warning): (.*?)$/;  
+export const diagnosticRe = /^\<stdin\>:(\d+):(\d+):(?:((?:\{.+?\})+):)? ((?:fatal )?error|warning): (.*?)\r?$/;
 function str2diagserv(str: string): vscode.DiagnosticSeverity {
     switch(str) {
         case 'fatal error': return vscode.DiagnosticSeverity.Error;


### PR DESCRIPTION
The output of clang for Windows uses windows line endings (`\r\n`). This change adds an optional `\r` at the end of the diagnostics regex so the output matches.