### PR TITLE
Option to disable auto completion

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/package.json
+++ b/package.json
@@ -71,7 +71,12 @@
            "type": "number",
            "default": 500,
            "description": "The delay after which diagnostic starts (in millisecond)"
-        }             
+        },
+        "clang.enableCompletion": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable auto completion"
+        }
       }
     }
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,12 +35,14 @@ export function activate(context: vscode.ExtensionContext) {
         confTester.test(editor.document.languageId);
     }, null, subscriptions);
     
-    context.subscriptions.push(
-        vscode.languages.registerCompletionItemProvider(
-            CLANG_MODE,
-            new completion.ClangCompletionItemProvider(),
-            '.', ':', '>'
-        ));
+    if(vscode.workspace.getConfiguration('clang').get('enableCompletion')) {
+        context.subscriptions.push(
+            vscode.languages.registerCompletionItemProvider(
+                CLANG_MODE,
+                new completion.ClangCompletionItemProvider(),
+                '.', ':', '>'
+            ));
+    }
 
 
     let diagnosticCollection = vscode.languages.createDiagnosticCollection('clang');


### PR DESCRIPTION
Added option to disable auto completion (default: on). I use a separate C/C++ IntelliSense (which uses GNU GLOBAL tagging) plugin which collides with this plugin. I use this primarily as a Linting plugin.