### PR TITLE
Add option for Clang compilation database.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/mitaki28/vscode-clang"
   },
   "bugs": {
-    "url": "https://github.com/mitaki28/vscode-clang/issues"  
+    "url": "https://github.com/mitaki28/vscode-clang/issues"
   },
   "homepage": "https://github.com/mitaki28/vscode-clang",
   "engines": {
@@ -38,6 +38,11 @@
       "type": "object",
       "title": "Clang configulation",
       "properties": {
+        "clang.compilationDatabase": {
+          "type": "string",
+          "default": "",
+          "description": "The path to a Clang compilation database (compile_commands.json)"
+        },
         "clang.executable": {
           "type": "string",
           "default": "clang",
@@ -67,12 +72,12 @@
           "default": [],
           "description": "Compiler options for Objective-C"
         },
-        
+
         "clang.diagnostic.enable": {
              "type": "boolean",
              "default": true,
              "description": "Enable diagnostic"
-        },     
+        },
         "clang.diagnostic.delay": {
            "type": "number",
            "default": 500,
@@ -82,8 +87,8 @@
              "type": "number",
              "default": 262144,
              "description": "Tolerable size of the clang output for diagnostic"
-        },        
-        
+        },
+
         "clang.completion.enable": {
              "type": "boolean",
              "default": true,
@@ -103,7 +108,7 @@
             "type": "boolean",
             "default": true,
              "description": "Complete macros"
-        }  
+        }
       }
     }
   },

--- a/src/clang.ts
+++ b/src/clang.ts
@@ -1,15 +1,16 @@
 import * as path from 'path';
 import * as child_process from 'child_process';
+import * as fs from 'fs';
 
 import * as vscode from 'vscode';
 
 import * as variable from './variable';
 
 const deprecatedMap: Map<string, string> = new Map<string, string>(
-    new Array<[string, string]>( 
+    new Array<[string, string]>(
         ['diagnostic.delay', 'diagnosticDelay'],
         ['diagnostic.enable', 'enableDiagnostic'],
-        ['completion.enable', 'enableCompletion']        
+        ['completion.enable', 'enableCompletion']
     )
 );
 
@@ -32,38 +33,65 @@ export function getConf<T>(name: string): T {
     return value;
 }
 
-export function command(language: string, ...options: string[]): [string, string[]] {
+interface ClangCompilationDBEntry {
+    // Absolute path to the source file.
+    file: string;
+
+    // Working directory that was used during compilation.
+    directory: string;
+
+    // The command that was used to compile the source file.
+    command: string;
+}
+
+export function command(language: string, path?: string, ...options: string[]): [string, string[]] {
+    if (path) {
+        let compilationDB = variable.resolve(getConf<string>('compilationDatabase'));
+        if (compilationDB) {
+            let db: ClangCompilationDBEntry[] = JSON.parse(fs.readFileSync(compilationDB, 'utf8'));
+            let entry: ClangCompilationDBEntry = db.find((entry: ClangCompilationDBEntry) => entry.file === path);
+            if (entry) {
+                // TODO This should be interpreted as shell args, just splitting on whitespace
+                //      will break with quoted paths that contain whitespace.
+                let args = entry.command.split(/\s+/);
+                args.push(...options);
+                let cmd = args.shift();
+                return [cmd, args];
+            }
+        }
+    }
+
     let cmd = variable.resolve(getConf<string>('executable'));
-    let args: string[] = [];    
+    let args: string[] = [];
     if (language === 'cpp') {
-        args.push('-x', 'c++');        
+        args.push('-x', 'c++');
         args.push(...getConf<string[]>('cxxflags').map(variable.resolve));
     } else if (language === 'c') {
-        args.push('-x', 'c');        
+        args.push('-x', 'c');
         args.push(...getConf<string[]>('cflags').map(variable.resolve));
     } else if (language === 'objective-c') {
-        args.push('-x', 'objective-c');        
+        args.push('-x', 'objective-c');
         args.push(...getConf<string[]>('objcflags').map(variable.resolve));
     }
     args.push(...options);
     return [cmd, args];
 }
 
-export function complete(language: string, line: number, char: number): [string, string[]] {
+export function complete(language: string, path: string, line: number, char: number): [string, string[]] {
     let args = [];
     args.push('-fsyntax-only');
     args.push('-fparse-all-comments');
     if (getConf<boolean>('completion.completeMacros')) {
-        args.push('-Xclang', '-code-completion-macros');        
+        args.push('-Xclang', '-code-completion-macros');
     }
     args.push('-Xclang', '-code-completion-brief-comments');
     args.push('-Xclang', `-code-completion-at=<stdin>:${line}:${char}`);
     args.push('-');
-    return command(language, ...args);    
+    return command(language, path, ...args);
 }
 
-export function check(language: string): [string, string[]] {
-    return command(language, 
+export function check(language: string, path: string): [string, string[]] {
+    return command(language, path,
         '-fsyntax-only',
         '-fno-caret-diagnostics',
         '-fdiagnostics-print-source-range-info',

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -23,7 +23,7 @@ function findPreviousDelimiter(document: vscode.TextDocument, position: vscode.P
     let char = position.character;
     const s = document.getText(new vscode.Range(line, 0, line, char));
     while (char > 0 && !isDelimiter(s[char - 1])) char--;
-    return new vscode.Position(line, char); 
+    return new vscode.Position(line, char);
 }
 
 
@@ -39,28 +39,29 @@ export class ClangCompletionItemProvider implements vscode.CompletionItemProvide
                     vscode.window.showWarningMessage(
                         'Completion was interpreted due to rack of buffer size. ' +
                         'The buffer size can be increased using `clang.completion.maxBuffer`. '
-                    );                    
+                    );
                 }
                 return [];
             }
         );
     }
-    
+
     fetchCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<string> {
-        // Currently, Clang does NOT complete token partially 
+        // Currently, Clang does NOT complete token partially
         // So we find a previous delimiter and start complete from there.
         let delPos = findPreviousDelimiter(document, position);
-        let [cmd, args] = clang.complete(document.languageId, delPos.line + 1, delPos.character + 1);
-        return execution.processString(cmd, args, 
+        let file = document.uri.fsPath;
+        let [cmd, args] = clang.complete(document.languageId, file, delPos.line + 1, delPos.character + 1);
+        return execution.processString(cmd, args,
             {
-                cwd: path.dirname(document.uri.fsPath),
+                cwd: path.dirname(file),
                 maxBuffer: clang.getConf<number>('completion.maxBuffer')
             },
             token,
             document.getText()
-        ).then((result) => result.stdout.toString());      
+        ).then((result) => result.stdout.toString());
     }
-    
+
     parseCompletionItem(line: string): vscode.CompletionItem|void {
         let matched = line.match(completionRe);
         if (matched == null) return;
@@ -93,19 +94,19 @@ export class ClangCompletionItemProvider implements vscode.CompletionItemProvide
         if (signature.indexOf('(') != -1) {
             item.kind = vscode.CompletionItemKind.Function;
         } else if (hasValue) {
-            item.kind = vscode.CompletionItemKind.Variable;            
+            item.kind = vscode.CompletionItemKind.Variable;
         } else {
             item.kind = vscode.CompletionItemKind.Class;
         }
         return item;
     }
-    
+
     parseCompletionItems(data: string): vscode.CompletionItem[] {
-        let result: vscode.CompletionItem[] = []; 
+        let result: vscode.CompletionItem[] = [];
         data.split(/\r\n|\r|\n/).forEach((line) => {
             let item = this.parseCompletionItem(line);
             if (item instanceof vscode.CompletionItem) {
-                result.push(item);            
+                result.push(item);
             }
         });
         return result;

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -31,9 +31,9 @@ export function processString(cmd: string, args: string[], opt: Option, token: v
                         reject(<FailedExecution>{
                             errorCode: ErrorCode.BufferLimitExceed,
                             result: <Result>{error, stdout, stderr}
-                        });                     
+                        });
                     } else {
-                        resolve(<Result>{error, stdout, stderr});                        
+                        resolve(<Result>{error, stdout, stderr});
                     }
                 }
             );


### PR DESCRIPTION
This PR makes it possible to use a [Clang compilation database](http://clang.llvm.org/docs/JSONCompilationDatabase.html) instead of having to specify compiler options manually, which might also not cover the needs of each source file.

I have verified that it works by creating a DB during each Xcode build with [this tool](https://github.com/alloy/clang-compilation-database-tool), but CMake and Ninja support the generation of these files too.

It seems like my VS Code settings stripped all trailing whitespace, let me know if that’s a problem for you.