### PR TITLE
Use compilation database file if it is present

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/mitaki28/vscode-clang"
   },
   "bugs": {
-    "url": "https://github.com/mitaki28/vscode-clang/issues"  
+    "url": "https://github.com/mitaki28/vscode-clang/issues"
   },
   "homepage": "https://github.com/mitaki28/vscode-clang",
   "engines": {
@@ -67,12 +67,17 @@
           "default": [],
           "description": "Compiler options for Objective-C"
         },
-        
+        "clang.compilationDatabase": {
+          "type": "string",
+          "default": "",
+          "description": "The path to a compilation database file"
+        },
+
         "clang.diagnostic.enable": {
              "type": "boolean",
              "default": true,
              "description": "Enable diagnostic"
-        },     
+        },
         "clang.diagnostic.delay": {
            "type": "number",
            "default": 500,
@@ -82,8 +87,8 @@
              "type": "number",
              "default": 262144,
              "description": "Tolerable size of the clang output for diagnostic"
-        },        
-        
+        },
+
         "clang.completion.enable": {
              "type": "boolean",
              "default": true,
@@ -103,7 +108,7 @@
             "type": "boolean",
             "default": true,
              "description": "Complete macros"
-        }  
+        }
       }
     }
   },

--- a/src/compile_db.ts
+++ b/src/compile_db.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 
 import * as variable from './variable';
+import * as clang from './clang';
 
 /// Represents an entry in a compilation database
 export interface CompilationDatabaseEntry {
@@ -46,10 +47,15 @@ export class CompilationDatabase {
         watcher.onDidChange(this._reloadDatabase.bind(this));
     }
 
+    // Open the default compilation database file
     public static openDefault(): CompilationDatabase {
-        const bindir_ = vscode.workspace.getConfiguration('cmake').get<string>('buildDirectory') || '${workspaceRoot}/build';
-        const bindir = variable.resolve(bindir_);
-        return new CompilationDatabase(path.join(bindir, 'compile_commands.json'));
+        let db_path = clang.getConf<string>('compilationDatabase');
+        if (!db_path) {
+            const bindir = vscode.workspace.getConfiguration('cmake').get<string>('buildDirectory') || '${workspaceRoot}/build';
+            db_path = path.join(bindir, 'compile_commands.json');
+        }
+        db_path = variable.resolve(db_path);
+        return new CompilationDatabase(db_path);
     }
 
     /// Reload the content of the database

--- a/src/compile_db.ts
+++ b/src/compile_db.ts
@@ -38,9 +38,12 @@ export class CompilationDatabase {
 
     constructor(dbpath: string) {
         this.databasePath = dbpath;
+        // We reload our compile flags when the database file changes. We don't
+        // want to read the db file each time we ask for flags, as this can add
+        // latency to completions, especially on systems with slower filesystems
         const watcher = this._watcher = vscode.workspace.createFileSystemWatcher(this.databasePath);
-        watcher.onDidChange(this._reloadDatabase);
-        watcher.onDidCreate(this._reloadDatabase);
+        watcher.onDidCreate(this._reloadDatabase.bind(this));
+        watcher.onDidChange(this._reloadDatabase.bind(this));
     }
 
     public static openDefault(): CompilationDatabase {

--- a/src/compile_db.ts
+++ b/src/compile_db.ts
@@ -1,0 +1,162 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+import * as vscode from 'vscode';
+
+import * as variable from './variable';
+
+/// Represents an entry in a compilation database
+export interface CompilationDatabaseEntry {
+    directory: string;
+    command: string;
+    file: string;
+}
+
+/// The info for a document returned by the CompilationDatabase class
+export interface CompileInfoForDocument {
+    cwd: string;
+    args: string[];
+}
+
+/// Helps access the CompilationDatabase
+export class CompilationDatabase {
+    private _watcher: vscode.FileSystemWatcher;
+    private _data: Array<CompilationDatabaseEntry>;
+
+    private _databasePath: string;
+    public get databasePath(): string {
+        return this._databasePath;
+    }
+    public set databasePath(v: string) {
+        this._databasePath = v;
+        this._reloadDatabase();
+    }
+
+    public get rawData() {
+        return this._data;
+    }
+
+    constructor(dbpath: string) {
+        this.databasePath = dbpath;
+        const watcher = this._watcher = vscode.workspace.createFileSystemWatcher(this.databasePath);
+        watcher.onDidChange(this._reloadDatabase);
+        watcher.onDidCreate(this._reloadDatabase);
+    }
+
+    public static openDefault(): CompilationDatabase {
+        const bindir_ = vscode.workspace.getConfiguration('cmake').get<string>('buildDirectory') || '${workspaceRoot}/build';
+        const bindir = variable.resolve(bindir_);
+        return new CompilationDatabase(path.join(bindir, 'compile_commands.json'));
+    }
+
+    /// Reload the content of the database
+    private _reloadDatabase(): Thenable<Array<CompilationDatabaseEntry>> {
+        return new Promise<Array<CompilationDatabaseEntry>>((resolve, reject) => {
+            fs.exists(this.databasePath, exists => {
+                if (!exists) {
+                    // If it isn't there, just say we have no entries
+                    resolve(this._data = []);
+                }
+                else {
+                    fs.readFile(this.databasePath, (err, buf) => {
+                        this._data = JSON.parse(buf.toString());
+                        resolve(this._data);
+                    });
+                }
+            });
+        });
+    }
+
+    // Gets the flags required to do completion. We only need include dirs,
+    // preprocessor defines, warnings, and standard settings
+    public static parseCommandLine(cmd: string): string[] {
+        // This regex will split a command line into a list of strings
+        const cmd_re = /('(\\'|[^'])*'|"(\\"|[^"])*"|(\\ |[^ ])+|[\w-]+)/g;
+        const all_args = cmd.match(cmd_re)
+            // Our regex will parse escaped quotes, but they remain. We must
+            // remote them ourselves
+            .map(arg => arg.replace(/\\(.)/g, '$1'));
+        let ret_args = [];
+        let i = 0;
+        for (let i = 0; i < all_args.length; ++i) {
+            let cur = all_args[i];
+            // Check for include directories
+            if (cur.startsWith('-I') || cur.startsWith('/I')) {
+                cur = cur.replace(/^\//, '-');
+                if (cur.length > 2) {
+                    ret_args.push(cur);
+                }
+                else {
+                    ret_args.push(cur, all_args[++i]);
+                }
+            }
+            // System includes should also be included
+            else if (cur.startsWith('-isystem')) {
+                if (cur.length == '-isystem'.length) {
+                    ret_args.push(cur);
+                }
+                else {
+                    ret_args.push(cur, all_args[++i]);
+                    continue;
+                }
+            }
+            // Check for preprocessor definitions
+            else if (cur.startsWith('-D') || cur.startsWith('/D')) {
+                cur = cur.replace(/^\//, '-');
+                if (cur.length > 2) {
+                    ret_args.push(cur);
+                }
+                else {
+                    ret_args.push(cur, all_args[++i]);
+                }
+            }
+            // Check for warning settings
+            else if (cur.startsWith('-W')) {
+                ret_args.push(cur);
+            }
+            else if (cur.startsWith('-std=')) {
+                ret_args.push(cur);
+            }
+        }
+        return ret_args;
+    }
+
+    public infoForDocument(filepath: string): CompileInfoForDocument {
+        const entries = this._data;
+        if (!entries)
+            return { args: [], cwd: null };
+        // Because we also want to have flags for header files, we
+        // must normalize the paths so that headers will receive
+        // the appropriate compilation flags
+        const stem = path => path
+            .replace('\\', '/')
+            .replace('source/', '')
+            .replace('include/', '')
+            .replace('src/', '')
+            .replace('include/')
+            .replace('.hpp', '')
+            .replace('.hxx', '')
+            .replace('.h++', '')
+            .replace('.hh', '')
+            .replace('.h', '')
+            .replace('.cpp', '')
+            .replace('.cxx', '')
+            .replace('.c++', '')
+            .replace('.cc', '')
+            .replace('.c', '');
+        const norm_path = stem(filepath);
+        let entry = entries.find(data => stem(data.file) === norm_path);
+        if (!entry) {
+            // Didn't find one for this file. Pick a random one :/
+            entry = entries[(Math.random() * entries.length) | 0];
+        }
+        let comp_args = CompilationDatabase.parseCommandLine(entry.command);
+        // Since we are compiling from stdin, we need to add the directory containing
+        // the file to the include paths for that file.
+        comp_args.push('-I' + path.dirname(filepath));
+        return {
+            args: comp_args,
+            cwd: entry.directory,
+        };
+    }
+}

--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -5,7 +5,9 @@ import * as path from 'path';
 import * as clang from './clang';
 import * as execution from './execution';
 
-export const diagnosticRe = /^\<stdin\>:(\d+):(\d+):(?:((?:\{.+?\})+):)? ((?:fatal )?error|warning): (.*?)$/;  
+import {CompilationDatabase} from './compile_db';
+
+export const diagnosticRe = /^\<stdin\>:(\d+):(\d+):(?:((?:\{.+?\})+):)? ((?:fatal )?error|warning): (.*?)$/;
 function str2diagserv(str: string): vscode.DiagnosticSeverity {
     switch(str) {
         case 'fatal error': return vscode.DiagnosticSeverity.Error;
@@ -45,7 +47,7 @@ export function registerDiagnosticProvider(selector: vscode.DocumentSelector, pr
         cancellers.set(uriStr, new vscode.CancellationTokenSource);
         delay(cancellers.get(uriStr).token).then(() => {
             cancellers.get(uriStr).dispose();
-            cancellers.set(uriStr, new vscode.CancellationTokenSource);                            
+            cancellers.set(uriStr, new vscode.CancellationTokenSource);
             return provider.provideDiagnostic(change.document, cancellers.get(uriStr).token);
         }).then((diagnostics) => {
             cancellers.get(uriStr).dispose();
@@ -59,7 +61,7 @@ export function registerDiagnosticProvider(selector: vscode.DocumentSelector, pr
             for (let canceller of Array.from(cancellers.values())) {
                 canceller.dispose();
             }
-            vscode.Disposable.from(...subsctiptions).dispose();  
+            vscode.Disposable.from(...subsctiptions).dispose();
         }
     };
 }
@@ -91,6 +93,8 @@ function parseRanges(s: string): vscode.Range[] {
 }
 
 export class ClangDiagnosticProvider implements DiagnosticProvider {
+    private _compilationDatabase: CompilationDatabase = CompilationDatabase.openDefault();
+
     provideDiagnostic(document: vscode.TextDocument, token: vscode.CancellationToken): Thenable<vscode.Diagnostic[]> {
         return this.fetchDiagnostic(document, token)
         .then(
@@ -110,15 +114,17 @@ export class ClangDiagnosticProvider implements DiagnosticProvider {
     }
 
     fetchDiagnostic(document: vscode.TextDocument, token: vscode.CancellationToken): Thenable<string> {
-        let [cmd, args] = clang.check(document.languageId);
-        return execution.processString(cmd, args, 
+        let [cmd, base_args] = clang.check(document.languageId);
+        const info = this._compilationDatabase.infoForDocument(document.fileName);
+        const args = base_args.concat(info.args);
+        return execution.processString(cmd, args,
             {
-                cwd: path.dirname(document.uri.fsPath),
-                maxBuffer: clang.getConf<number>('diagnostic.maxBuffer')                    
+                cwd: info.cwd || path.dirname(document.uri.fsPath),
+                maxBuffer: clang.getConf<number>('diagnostic.maxBuffer')
             },
             token,
             document.getText()
-        ).then((result) => result.stderr.toString());   
+        ).then((result) => result.stderr.toString());
     }
 
     parseDiagnostic(data: string): vscode.Diagnostic[] {
@@ -135,9 +141,9 @@ export class ClangDiagnosticProvider implements DiagnosticProvider {
                 let ranges = parseRanges(matched[3]);
                 range = new vscode.Range(
                     ranges[0].start.line - 1,
-                    ranges[0].start.character - 1,                    
+                    ranges[0].start.character - 1,
                     ranges[ranges.length - 1].end.line - 1,
-                    ranges[ranges.length - 1].end.character - 1                    
+                    ranges[ranges.length - 1].end.character - 1
                 );
             }
             let msg: string = matched[5];
@@ -145,6 +151,6 @@ export class ClangDiagnosticProvider implements DiagnosticProvider {
 
             result.push(new vscode.Diagnostic(range, msg, type));
         });
-        return result; 
-    }    
+        return result;
+    }
 }


### PR DESCRIPTION
This change makes it such that the completion and diagnostic provider read more clang compile flags from a compilation database if it is available. A few notes:

- The database is reloaded when changes are detected, and the settings therein are stored in memory to keep latency low when performing completions.
- Options are prepended to the ``clang.*flags`` settings.
- Because headers don't have an entry in the database, the loader performs path normalization/stemming to produce a "best guess" at what the flags for processing a header should be: usually it will use the flags of the header's corresponding source file.
- Flags are filtered and pre-processed to be compatible with the ``clang -cc1 -fsyntax-only``  mode. Only relevant flags from the database are used.