### PR TITLE
Add Handling for Objective-cpp Language Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C/C++ Clang Command Adapter
 
-Completion and Diagnostic for C/C++/Objective-C using [Clang](http://clang.llvm.org/) command.
+Completion and Diagnostic for C, C++, and Objective-C/C++ using [Clang](http://clang.llvm.org/) command.
 
 ## Important Notes
 
@@ -22,7 +22,7 @@ You can use configuration interface of Visual Studio Code. (Press `F1` and type 
 
 ### Common
 - `clang.executable`: Clang command or the path to the Clang executable (default: `clang`)
-- `clang.cflags`, `clang.cxxflags`, `clang.objcflags`: Compiler Options for C/C++/Objective-C
+- `clang.cflags`, `clang.cxxflags`, `clang.objcflags`: Compiler Options for C/C++/Objective-C and Objective-C++
 
 ### Completion
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-clang",
   "displayName": "C/C++ Clang Command Adapter",
-  "description": "Completion and Diagnostic for C/C++/Objective-C using Clang Command",
+  "description": "Completion and Diagnostic for C, C++, and Objective-C/C++ using Clang Command",
   "version": "0.2.2",
   "publisher": "mitaki28",
   "license": "MIT",
@@ -25,6 +25,7 @@
     "onLanguage:cpp",
     "onLanguage:c",
     "onLanguage:objective-c",
+    "onLanguage:objective-cpp",
     "onCommand:clang.showExecConf"
   ],
   "main": "./out/src/extension",
@@ -67,7 +68,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Compiler options for Objective-C"
+          "description": "Compiler options for Objective-C/Objective-C++"
         },
         "clang.diagnostic.enable": {
           "type": "boolean",

--- a/src/clang.ts
+++ b/src/clang.ts
@@ -44,6 +44,9 @@ export function command(language: string, ...options: string[]): [string, string
     } else if (language === "objective-c") {
         args.push("-x", "objective-c");
         args.push(...getConf<string[]>("objcflags").map(variable.resolve));
+    }  else if (language === "objective-cpp") {
+        args.push("-x", "objective-c++");
+        args.push(...getConf<string[]>("objcflags").map(variable.resolve));
     }
     args.push(...options);
     return [cmd, args];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,8 @@ import * as completion from "./completion";
 const CLANG_MODE: vscode.DocumentSelector = [
     { language: "cpp", scheme: "file" },
     { language: "c", scheme: "file" },
-    { language: "objective-c", scheme: "file" }
+    { language: "objective-c", scheme: "file" },
+    { language: "objective-cpp", scheme: "file" }
 ];
 
 class ResidentExtension implements vscode.Disposable {
@@ -74,7 +75,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerTextEditorCommand("clang.showExecConf",
         (editor: vscode.TextEditor, edit: vscode.TextEditorEdit) => {
             if (!vscode.languages.match(CLANG_MODE, editor.document)) {
-                vscode.window.showErrorMessage(`Current language is not C, C++ or Objective-C`);
+                vscode.window.showErrorMessage(`Current language is not C, C++, Objective-C/C++`);
                 return;
             }
             confViewer.show(editor.document);


### PR DESCRIPTION
VSCode 1.11 and the current insiders builds introduce a new `objective-cpp` language mode for Objective-c++ (https://github.com/Microsoft/vscode/pull/21599). Previously, `.mm` files were treated as plain old c++.

This change adds support for the new Objective-C++ language mode to this extension

https://github.com/Microsoft/vscode/issues/21775