### PR TITLE
Fix 'no newline at end of file' warning/error

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -21,7 +21,7 @@ export class ConfigurationTester implements vscode.Disposable {
             }
             this.processes.delete(proc.pid);
         });
-        proc.stdin.end("int main() { return 0; }");
+        proc.stdin.end("int main() { return 0; }\n");
         this.processes.set(proc.pid, proc);
     }
     dispose() {


### PR DESCRIPTION
With specific compiler settings (error on no newline at end of file) the ConfigurationTester would produce an error.

Please the attached a pull request for (a simple) fix.

![screen shot 2017-05-19 at 16 29 09](https://cloud.githubusercontent.com/assets/4981772/26253529/fe4b48da-3cb3-11e7-863f-c4de1987f460.png)
