### PR TITLE
fix heavy CPU usage when typing fast (#66)

### DIFF
--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -40,6 +40,7 @@ export function registerDiagnosticProvider(selector: vscode.DocumentSelector, pr
         const uri = change.document.uri;
         const uriStr = uri.toString();
         if (cancellers.has(uriStr)) {
+            cancellers.get(uriStr).cancel();
             cancellers.get(uriStr).dispose();
         }
         cancellers.set(uriStr, new vscode.CancellationTokenSource);
@@ -57,6 +58,7 @@ export function registerDiagnosticProvider(selector: vscode.DocumentSelector, pr
         dispose() {
             collection.dispose();
             for (let canceller of Array.from(cancellers.values())) {
+                canceller.cancel();
                 canceller.dispose();
             }
             vscode.Disposable.from(...subsctiptions).dispose();


### PR DESCRIPTION
This problem is caused by missing cancellation for existing processes.

Please see https://github.com/mitaki28/vscode-clang/issues/66#issuecomment-429521093.